### PR TITLE
新增公告寄送功能

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 
 NEXT_PUBLIC_SUPABASE_URL=null
 NEXT_PUBLIC_SUPABASE_ANON_KEY=null
+SUPABASE_SERVICE_ROLE_KEY=null
 
 SMTP_HOST=smtp.gmail.com
 SMTP_USERNAME=ncuedorm10service@gmail.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.53.0",
         "mime": "^4.0.7",
         "next": "15.4.4",
+        "nodemailer": "^6.9.11",
         "quill": "^2.0.3",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -1909,6 +1910,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/parchment": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "15.4.4",
     "quill": "^2.0.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/send-announcement/route.js
+++ b/src/app/api/send-announcement/route.js
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
+import { supabaseServer } from '@/lib/supabase/server';
+
+export async function POST(request) {
+  try {
+    const { announcementId } = await request.json();
+    if (!announcementId) {
+      return NextResponse.json({ error: '缺少公告 ID' }, { status: 400 });
+    }
+
+    // 取得公告資訊
+    const { data: announcement, error: annError } = await supabaseServer
+      .from('announcements')
+      .select('*')
+      .eq('id', announcementId)
+      .single();
+
+    if (annError || !announcement) {
+      console.error('取得公告失敗', annError);
+      return NextResponse.json({ error: '無法取得公告資料' }, { status: 500 });
+    }
+
+    // 取得所有使用者的 email
+    const { data: users, error: userError } = await supabaseServer.auth.admin.listUsers();
+    if (userError) {
+      console.error('取得使用者清單失敗', userError);
+      return NextResponse.json({ error: '無法取得使用者清單' }, { status: 500 });
+    }
+
+    const emails = users?.users?.map((u) => u.email).filter(Boolean);
+    if (!emails || emails.length === 0) {
+      return NextResponse.json({ error: '沒有可寄送的 Email' }, { status: 400 });
+    }
+
+    // 建立寄信 transporter
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || '465', 10),
+      secure: process.env.SMTP_SECURE === 'ssl',
+      auth: {
+        user: process.env.SMTP_USERNAME,
+        pass: process.env.SMTP_PASSWORD,
+      },
+    });
+
+    const mailOptions = {
+      from: `${process.env.MAIL_FROM_NAME} <${process.env.MAIL_FROM_ADDRESS}>`,
+      to: emails.join(','),
+      subject: `【公告通知】${announcement.title}`,
+      text: announcement.summary || '',
+    };
+
+    await transporter.sendMail(mailOptions);
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('寄送公告失敗', err);
+    return NextResponse.json({ error: '寄送失敗' }, { status: 500 });
+  }
+}

--- a/src/components/admin/AnnouncementsTab.jsx
+++ b/src/components/admin/AnnouncementsTab.jsx
@@ -6,6 +6,23 @@ import CreateAnnouncementModal from '@/components/CreateAnnouncementModal';
 import Button from '@/components/ui/Button';
 import IconButton from '@/components/ui/IconButton';
 
+// 寄送公告給所有使用者
+const sendAnnouncement = async (id) => {
+  try {
+    const res = await fetch('/api/send-announcement', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ announcementId: id }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || '寄送失敗');
+    alert('寄送成功');
+  } catch (err) {
+    console.error(err);
+    alert('寄送失敗');
+  }
+};
+
 export default function AnnouncementsTab() {
   const [announcements, setAnnouncements] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -95,6 +112,13 @@ export default function AnnouncementsTab() {
                         </Button>
                         <Button variant="link" className="text-red-600 p-0">
                           刪除
+                        </Button>
+                        <Button
+                          variant="link"
+                          className="text-green-600 p-0"
+                          onClick={() => sendAnnouncement(announcement.id)}
+                        >
+                          寄送
                         </Button>
                       </div>
                     </td>

--- a/src/lib/supabase/server.js
+++ b/src/lib/supabase/server.js
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Missing Supabase environment variables for server client.');
+}
+
+export const supabaseServer = createClient(supabaseUrl, serviceRoleKey);


### PR DESCRIPTION
## Summary
- add supabase server client and mailer API for sending announcements
- allow SMTP and service role config in `.env.template`
- add button to send announcement emails in admin tab
- install nodemailer

## Testing
- `npm list nodemailer`
- `npm run lint` *(fails: interactive prompt about eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6889ea730a508323bf38fd972200411d