### PR TITLE
新增公告附件上傳與展示功能

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
+import AnnouncementList from "@/components/AnnouncementList";
 
 
 export default function Home() {
@@ -26,6 +27,7 @@ export default function Home() {
           這裡是您獲取獎助學金資訊的最佳平台，我們提供完整的獎學金查詢和申請服務。
         </p>
       </div>
+      <AnnouncementList />
     </main>
   </div>
 );

--- a/src/components/AnnouncementList.jsx
+++ b/src/components/AnnouncementList.jsx
@@ -14,8 +14,8 @@ export default function AnnouncementList() {
       setLoading(true);
       const { data, error } = await supabase
         .from('announcements')
-        .select('*')
-        .eq('status', 'published')
+        .select('*, attachments(*)')
+        .eq('is_active', true)
         .order('application_deadline', { ascending: true });
       if (!error) {
         setAnnouncements(data || []);
@@ -48,6 +48,11 @@ export default function AnnouncementList() {
     };
     return map[cat] || 'bg-gray-500';
   };
+
+  const getPublicUrl = (path) => {
+    const { data } = supabase.storage.from('attachments').getPublicUrl(path)
+    return data.publicUrl
+  }
 
   return (
     <div className="container mx-auto p-4 sm:p-6 lg:p-8">
@@ -100,6 +105,15 @@ export default function AnnouncementList() {
                     <div className="flex-1">
                       <h3 className="font-semibold text-lg text-gray-900">{item.title}</h3>
                       <p className="text-sm text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                      {item.attachments && item.attachments.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {item.attachments.map(att => (
+                            <a key={att.id} href={getPublicUrl(att.stored_file_path)} target="_blank" className="text-blue-600 underline text-xs">
+                              {att.file_name}
+                            </a>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/AttachmentUploader.jsx
+++ b/src/components/AttachmentUploader.jsx
@@ -1,0 +1,52 @@
+import { useRef } from 'react'
+
+export default function AttachmentUploader({ files = [], setFiles, disabled }) {
+  const fileInputRef = useRef(null)
+
+  const handleFileChange = (e) => {
+    const selected = Array.from(e.target.files || [])
+    if (selected.length > 0) {
+      setFiles([...files, ...selected])
+    }
+    e.target.value = ''
+  }
+
+  const handleRemove = (idx) => {
+    setFiles(files.filter((_, i) => i !== idx))
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={disabled}
+        className="px-3 py-1.5 bg-indigo-600 text-white rounded hover:bg-indigo-700 text-sm"
+      >
+        選擇檔案
+      </button>
+      <input
+        type="file"
+        multiple
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        className="hidden"
+        disabled={disabled}
+      />
+      <ul className="mt-2 space-y-1">
+        {files.map((f, idx) => (
+          <li key={idx} className="flex justify-between items-center bg-gray-100 rounded px-2 py-1 text-sm">
+            <span className="break-all">{f.name}</span>
+            <button
+              type="button"
+              onClick={() => handleRemove(idx)}
+              className="text-red-500 text-xs ml-2"
+            >
+              移除
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新增 `AttachmentUploader` 元件以支援多檔案上傳
- 於 `CreateAnnouncementModal`、`UpdateAnnouncementModal` 增加附件欄位及上傳邏輯
- 更新 `AnnouncementList`，讀取附件資訊並提供下載連結
- 首頁引入 `AnnouncementList` 展示最新公告

## Testing
- `npm run build` *(fails: Can't resolve '@supabase/auth-helpers-nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_6889f8be43508323acb63d9967e67f25