### PR TITLE
主頁增加公告列表並預設新公告上架

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
+import AnnouncementList from "@/components/AnnouncementList";
 
 
 export default function Home() {
@@ -26,6 +27,7 @@ export default function Home() {
           這裡是您獲取獎助學金資訊的最佳平台，我們提供完整的獎學金查詢和申請服務。
         </p>
       </div>
+      <AnnouncementList />
     </main>
   </div>
 );

--- a/src/components/CreateAnnouncementModal.jsx
+++ b/src/components/CreateAnnouncementModal.jsx
@@ -214,7 +214,7 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
     const [formData, setFormData] = useState({
         title: '',
         summary: '',
-        status: '0',
+        status: '1',
         category: '',
         application_deadline: '',
         target_audience: '',
@@ -420,7 +420,7 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
             setFormData(prev => ({
                 ...prev,
                 ...aiResponse,
-                status: prev.status || '0', 
+                status: prev.status || '1',
             }));
             
             setCurrentStep(2);
@@ -515,7 +515,7 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
             setSelectedFile(null);
             setShowDeleteConfirm(false);
             setFormData({
-                title: '', summary: '', status: '0', category: '',
+                title: '', summary: '', status: '1', category: '',
                 application_deadline: '', target_audience: '', application_limitations: '',
                 submission_method: '', external_urls: '',
             });


### PR DESCRIPTION
## Summary
- 主頁掛載 `AnnouncementList` 顯示各獎學金公告
- 調整 `CreateAnnouncementModal` 表單預設狀態為 `上架`

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: build errors and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6889fbd785a4832396aa9bebb88bbee0