### PR TITLE
Add profile edit page

### DIFF
--- a/src/app/(user)/profile/edit/page.jsx
+++ b/src/app/(user)/profile/edit/page.jsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import Button from "@/components/ui/Button";
+
+export default function EditProfilePage() {
+  const router = useRouter();
+  const { user, loading, isAuthenticated, updateProfile } = useAuth();
+  const [formData, setFormData] = useState({
+    name: "",
+    student_id: "",
+    department: "",
+    year: ""
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      router.push("/login");
+    }
+  }, [isAuthenticated, loading, router]);
+
+  useEffect(() => {
+    if (user) {
+      setFormData({
+        name: user.user_metadata?.name || "",
+        student_id: user.user_metadata?.student_id || "",
+        department: user.user_metadata?.department || "",
+        year: user.user_metadata?.year || ""
+      });
+    }
+  }, [user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    const result = await updateProfile(formData);
+    setSaving(false);
+    if (result.success) {
+      router.push("/profile");
+    } else {
+      alert(result.error);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">載入中...</div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow w-full max-w-lg space-y-4">
+        <h1 className="text-2xl font-bold mb-4">編輯個人資料</h1>
+        <div>
+          <label className="block text-sm font-medium mb-1">姓名</label>
+          <input
+            type="text"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">學號</label>
+          <input
+            type="text"
+            name="student_id"
+            value={formData.student_id}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">系所</label>
+          <input
+            type="text"
+            name="department"
+            value={formData.department}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">年級</label>
+          <input
+            type="text"
+            name="year"
+            value={formData.year}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={() => router.back()}>取消</Button>
+          <Button type="submit" loading={saving}>儲存</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(user)/profile/page.jsx
+++ b/src/app/(user)/profile/page.jsx
@@ -61,15 +61,16 @@ export default function ProfilePage() {
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-white rounded-lg shadow-lg p-8">
           <div className="flex justify-between items-center mb-8">
-            <h1 className="text-3xl font-bold text-gray-900">
-              個人資料
-            </h1>
-            <button
-              onClick={handleSignOut}
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-            >
-              登出
-            </button>
+            <h1 className="text-3xl font-bold text-gray-900">個人資料</h1>
+            <div className="flex gap-2">
+              <Button variant="secondary" onClick={() => router.push('/profile/edit')}>編輯資料</Button>
+              <button
+                onClick={handleSignOut}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+              >
+                登出
+              </button>
+            </div>
           </div>
 
           {profileData && (

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -127,6 +127,21 @@ export const AuthProvider = ({ children }) => {
     return result;
   };
 
+  // 更新個人資料
+  const updateProfile = async (profileData) => {
+    setError(null);
+    const result = await authService.updateProfile(profileData);
+    if (result.success) {
+      const refreshed = await authService.getCurrentUser();
+      if (refreshed.success) {
+        setUser(refreshed.user);
+      }
+    } else {
+      setError(result.error);
+    }
+    return result;
+  };
+
   const verifyOtp = async (email, token, type = 'email') => {
     setError(null);
     const result = await authService.verifyOtp(email, token, type);
@@ -154,6 +169,7 @@ export const AuthProvider = ({ children }) => {
     signOut,
     resetPassword,
     updatePassword,
+    updateProfile,
     verifyOtp,
     resendOtp,
     isAuthenticated: !!user,

--- a/src/lib/supabase/auth.js
+++ b/src/lib/supabase/auth.js
@@ -135,10 +135,40 @@ export const authService = {
           const { error } = await supabase.auth.updateUser({
             password
           });
-          
+
           if (error) throw error;
           return { success: true };
         } catch (error) {
+          return { success: false, error: error.message };
+        }
+      },
+
+      // 更新使用者個人資料
+      async updateProfile({ name, student_id, department, year }) {
+        try {
+          const { data, error } = await supabase.auth.updateUser({
+            data: { name, student_id, department, year }
+          });
+
+          if (error) throw error;
+
+          const userId = data.user.id;
+
+          const { error: profileError } = await supabase
+            .from('profiles')
+            .update({
+              username: name,
+              student_id,
+              department,
+              year
+            })
+            .eq('id', userId);
+
+          if (profileError) throw profileError;
+
+          return { success: true, user: data.user };
+        } catch (error) {
+          console.error('更新個人資料失敗:', error);
           return { success: false, error: error.message };
         }
       },


### PR DESCRIPTION
## Summary
- allow updating user profile via auth service
- expose updateProfile in auth context
- add profile edit page with form
- link to edit page from profile page

## Testing
- `npm run build` *(fails: Can't resolve '@supabase/auth-helpers-nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_688a024467408323bc297f2a29128217